### PR TITLE
Destroy command update

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -50,14 +50,35 @@ Spawn a blue abrams
 
 ### !destroy
 
-Destroy a unit or spawner near the map marker. The closest unit or spawner to the marker will be destroyed.
-You can also specific either unit or spawner type to destroy, and it will only destroy that type.
+Destroy units or spawners near the map marker. The closest unit or spawner to the marker will be destroyed, if no radius is specified.
+You can also specify either unit or spawner type to destroy, and it will only destroy that type. You can also specify the coalition. Default coalition is the coalition of the player who created the map marker.
 
 **syntax**
 
 ```
-!destroy <toDestroy:optional>
+!destroy <toDestroy:optional> <radius:optional> <coalition:optional>
 ```
+optional with rad or radius as keyword for the specified radius:
+```
+!destroy <toDestroy:optional> radius <radius:optional> <coalition:optional>
+```
+
+available types to destroy:
+
+```
+unit
+spawner
+```
+default: both
+
+available coalitions:
+
+```
+blue
+red
+all
+```
+default: player coalition
 
 **examples**
 
@@ -77,6 +98,24 @@ Destroy spawner closest the map marker:
 
 ```
 !destroy spawner
+```
+
+Destroy everything from your own coalition in 1000 meter radius:
+
+```
+!destroy 1000
+```
+
+Destroy blue units in 500 meter radius:
+
+```
+!destroy blue unit 500
+```
+
+Destroy everything of blue and red coalition using the optional radius keyword for a 1000 meter radius:
+
+```
+!destroy all radius 1000
 ```
 
 ### !spawngroup

--- a/src/autoRespawn/main.ts
+++ b/src/autoRespawn/main.ts
@@ -403,7 +403,7 @@ async function handleMarkChangeEvent(event: MarkChangeEvent) {
 
       // if radius is given, delete each spawner inside radius
       if(command.radius) {
-        nearby.map(async element => {
+        await Promise.all(nearby.map(async element => {
           const { lat, lon, alt } = element
           const spawnerPosition = { lat, lon, alt }
           if (distanceFrom(position, spawnerPosition) <= radius) {
@@ -419,7 +419,7 @@ async function handleMarkChangeEvent(event: MarkChangeEvent) {
       
             await outText(`Spawner ${spawnerId} destroyed`)
           }
-        });
+        }))
       }
       // if no radius given, delete closest spawner
       else {

--- a/src/autoRespawn/main.ts
+++ b/src/autoRespawn/main.ts
@@ -40,9 +40,7 @@ import {
 } from '../mission'
 import { closestPointOnRoads, findPathOnRoads, RoadType } from '../land'
 import { driveGroundGroup } from '../group'
-import {
-  distanceFrom,
-} from '../common'
+import { distanceFrom } from '../common'
 
 const UNIT_MAXIMUM_DISPLACEMENT_TO_SPAWNER_METERS = 100000
 const SPAWNER_MINIMUM_DISPLACEMENT_METERS = 250
@@ -396,30 +394,32 @@ async function handleMarkChangeEvent(event: MarkChangeEvent) {
       const nearby = await nearbySpawners({
         position,
         accuracy: radius,
-        coalition: coalition, 
+        coalition: coalition,
       })
 
       equal(nearby.length > 0, true, 'No existing spawners found')
 
       // if radius is given, delete each spawner inside radius
-      if(command.radius) {
-        await Promise.all(nearby.map(async element => {
-          const { lat, lon, alt } = element
-          const spawnerPosition = { lat, lon, alt }
-          if (distanceFrom(position, spawnerPosition) <= radius) {
-            const { spawnerId } = element
-            await spawnerDestroyed(spawnerId) // destroy
+      if (command.radius) {
+        await Promise.all(
+          nearby.map(async element => {
+            const { lat, lon, alt } = element
+            const spawnerPosition = { lat, lon, alt }
+            if (distanceFrom(position, spawnerPosition) <= radius) {
+              const { spawnerId } = element
+              await spawnerDestroyed(spawnerId) // destroy
 
-            // remove existing spawner marker
-            const existingMarker = await findSpawnerMarker(spawnerId)
-      
-            if (existingMarker) {
-              await removeMapMark(existingMarker.id)
+              // remove existing spawner marker
+              const existingMarker = await findSpawnerMarker(spawnerId)
+
+              if (existingMarker) {
+                await removeMapMark(existingMarker.id)
+              }
+
+              await outText(`Spawner ${spawnerId} destroyed`)
             }
-      
-            await outText(`Spawner ${spawnerId} destroyed`)
-          }
-        }))
+          })
+        )
       }
       // if no radius given, delete closest spawner
       else {
@@ -428,11 +428,11 @@ async function handleMarkChangeEvent(event: MarkChangeEvent) {
 
         // remove existing spawner marker
         const existingMarker = await findSpawnerMarker(spawnerId)
-  
+
         if (existingMarker) {
           await removeMapMark(existingMarker.id)
         }
-  
+
         await outText(`Spawner ${spawnerId} destroyed`)
       }
 

--- a/src/autoRespawn/main.ts
+++ b/src/autoRespawn/main.ts
@@ -40,6 +40,9 @@ import {
 } from '../mission'
 import { closestPointOnRoads, findPathOnRoads, RoadType } from '../land'
 import { driveGroundGroup } from '../group'
+import {
+  distanceFrom,
+} from '../common'
 
 const UNIT_MAXIMUM_DISPLACEMENT_TO_SPAWNER_METERS = 100000
 const SPAWNER_MINIMUM_DISPLACEMENT_METERS = 250
@@ -381,30 +384,59 @@ async function handleMarkChangeEvent(event: MarkChangeEvent) {
       }
 
       const { position } = addedMark
+      const { coalition = addedMark.coalition } = command
+
+      let radius = SPAWNER_MINIMUM_DISPLACEMENT_METERS
+
+      if (command.radius) {
+        radius = command.radius
+      }
 
       // make sure spawner meets minimum displacement requirement
       const nearby = await nearbySpawners({
         position,
-        accuracy: SPAWNER_MINIMUM_DISPLACEMENT_METERS,
-        coalition: Coalition.COALITION_ALL, // TODO: take a red or blue word/string from parser here
+        accuracy: radius,
+        coalition: coalition, 
       })
 
       equal(nearby.length > 0, true, 'No existing spawners found')
 
-      const [{ spawnerId }] = nearby
+      // if radius is given, delete each spawner inside radius
+      if(command.radius) {
+        nearby.map(async element => {
+          const { lat, lon, alt } = element
+          const spawnerPosition = { lat, lon, alt }
+          if (distanceFrom(position, spawnerPosition) <= radius) {
+            const { spawnerId } = element
+            await spawnerDestroyed(spawnerId) // destroy
 
-      await spawnerDestroyed(spawnerId) // destroy
+            // remove existing spawner marker
+            const existingMarker = await findSpawnerMarker(spawnerId)
+      
+            if (existingMarker) {
+              await removeMapMark(existingMarker.id)
+            }
+      
+            await outText(`Spawner ${spawnerId} destroyed`)
+          }
+        });
+      }
+      // if no radius given, delete closest spawner
+      else {
+        const { spawnerId } = nearby[0]
+        await spawnerDestroyed(spawnerId) // destroy
 
-      await removeMapMark(addedMark.id)
-
-      // remove existing spawner marker
-      const existingMarker = await findSpawnerMarker(spawnerId)
-
-      if (existingMarker) {
-        await removeMapMark(existingMarker.id)
+        // remove existing spawner marker
+        const existingMarker = await findSpawnerMarker(spawnerId)
+  
+        if (existingMarker) {
+          await removeMapMark(existingMarker.id)
+        }
+  
+        await outText(`Spawner ${spawnerId} destroyed`)
       }
 
-      await outText(`Spawner ${spawnerId} destroyed`)
+      await removeMapMark(addedMark.id)
     }
   }
 }

--- a/src/commands/parser/parser.ts
+++ b/src/commands/parser/parser.ts
@@ -122,7 +122,7 @@ function processCommand(lexer: Lexer): Command {
     let typeToDestroy: ToDestroy | undefined
     let coalition: Coalition | undefined
     let radius: number | undefined
-    
+
     const parseParts = (): void => {
       const nextToken = lexer.nextToken()
 
@@ -170,7 +170,7 @@ function processCommand(lexer: Lexer): Command {
           }
 
           radius = radiusValueToken.value
-          
+
           return parseParts()
         }
         return parseParts()

--- a/src/commands/parser/parser.ts
+++ b/src/commands/parser/parser.ts
@@ -173,7 +173,7 @@ function processCommand(lexer: Lexer): Command {
 
           return parseParts()
         }
-        return parseParts()
+        throw new Error('unexpected token found')
       }
 
       // if number, assume it's radius
@@ -185,30 +185,10 @@ function processCommand(lexer: Lexer): Command {
 
     parseParts()
 
-    if (typeToDestroy != undefined && radius != undefined) {
-      return {
-        type: CommandType.Destroy,
-        toDestroy: typeToDestroy,
-        radius: radius,
-        coalition: coalition,
-      }
-    }
-    if (typeToDestroy != undefined) {
-      return {
-        type: CommandType.Destroy,
-        toDestroy: typeToDestroy,
-        coalition: coalition,
-      }
-    }
-    if (radius != undefined) {
-      return {
-        type: CommandType.Destroy,
-        radius: radius,
-        coalition: coalition,
-      }
-    }
     return {
       type: CommandType.Destroy,
+      toDestroy: typeToDestroy,
+      radius: radius,
       coalition: coalition,
     }
   }

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -33,8 +33,8 @@ export interface DefineSpawnGroupCommand extends Omit<CommandShape, 'args'> {
 
 export interface DestroyCommand extends Omit<CommandShape, 'args'> {
   type: CommandType.Destroy
-  toDestroy?: ToDestroy
-  radius?: number
+  toDestroy: ToDestroy | undefined
+  radius: number | undefined
   coalition: Coalition | undefined
 }
 

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -34,6 +34,8 @@ export interface DefineSpawnGroupCommand extends Omit<CommandShape, 'args'> {
 export interface DestroyCommand extends Omit<CommandShape, 'args'> {
   type: CommandType.Destroy
   toDestroy?: ToDestroy
+  radius?: number
+  coalition: Coalition | undefined
 }
 
 export interface SpawnCommand extends Omit<CommandShape, 'args'> {

--- a/src/db/units.ts
+++ b/src/db/units.ts
@@ -158,7 +158,11 @@ export async function findUnit(name: string): Promise<Unit | undefined> {
  * @param position PositionLL
  * @param accuracy accuracy of search in meters
  */
-export async function nearbyUnits(position: PositionLL, accuracy: number, coalition: Coalition) {
+export async function nearbyUnits(
+  position: PositionLL,
+  accuracy: number,
+  coalition: Coalition
+) {
   const { lat, lon } = position
 
   let query = knex('units')

--- a/src/spawnUnits/main.ts
+++ b/src/spawnUnits/main.ts
@@ -210,13 +210,13 @@ async function handleMarkChangeEvent(event: MarkChangeEvent) {
 
       // if radius is given delete each unit inside radius
       if(command.radius) {
-        foundUnits.map(async (element) => {
+        await Promise.all(foundUnits.map(async (element) => {
           if (element.distance <= radius) {
             const { name } = element.unit
             await destroy(name)
             await unitGone({name})
           }
-        })
+        }))
       }
       // if no radius given, delete closest unit
       else {

--- a/src/spawnUnits/main.ts
+++ b/src/spawnUnits/main.ts
@@ -197,26 +197,29 @@ async function handleMarkChangeEvent(event: MarkChangeEvent) {
         radius = command.radius
       }
 
-      const foundUnits = (await nearbyUnits(markPosition, radius, coalition))
-        .map(unit => {
-          const { lat, lon, alt } = unit
-          const unitPosition = { lat, lon, alt }
-          return { unit, distance: distanceFrom(markPosition, unitPosition) }
-        })
+      const foundUnits = (
+        await nearbyUnits(markPosition, radius, coalition)
+      ).map(unit => {
+        const { lat, lon, alt } = unit
+        const unitPosition = { lat, lon, alt }
+        return { unit, distance: distanceFrom(markPosition, unitPosition) }
+      })
 
       if (foundUnits.length < 1) {
         throw new Error('no nearby units found to destroy')
       }
 
       // if radius is given delete each unit inside radius
-      if(command.radius) {
-        await Promise.all(foundUnits.map(async (element) => {
-          if (element.distance <= radius) {
-            const { name } = element.unit
-            await destroy(name)
-            await unitGone({name})
-          }
-        }))
+      if (command.radius) {
+        await Promise.all(
+          foundUnits.map(async element => {
+            if (element.distance <= radius) {
+              const { name } = element.unit
+              await destroy(name)
+              await unitGone({ name })
+            }
+          })
+        )
       }
       // if no radius given, delete closest unit
       else {


### PR DESCRIPTION
Updating the destroy command to take an optional radius and optional coalition to allow destruction of more than one thing at a time.

following documentation describes the added features: 

**!destroy**
Destroy units or spawners near the map marker. The closest unit or spawner to the marker will be destroyed, if no radius is specified.
You can also specify either unit or spawner type to destroy, and it will only destroy that type. You can also specify the coalition. Default coalition is the coalition of the player of created the map marker.

**syntax**

```
!destroy <toDestroy:optional> <radius:optional> <coalition:optional>
```
or with rad or radius as keyword for the specified radius:
```
!destroy <toDestroy:optional> radius <radius:optional> <coalition:optional>
```

available types to destroy:

```
unit
spawner
```
default: both

available coalitions:

```
blue
red
all
```
default: player coalition

**examples**

Destroy the closest thing the map marker (either unit or spawner):

```
!destroy
```

Destroy unit closest the map marker:

```
!destroy unit
```

Destroy spawner closest the map marker:

```
!destroy spawner
```

Destroy everything from your own coalition in 1000 meter radius:

```
!destroy 1000
```

Destroy blue units in 500 meter radius:

```
!destroy blue unit 500
```

Destroy everything of blue and red coalition using the optional radius keyword for a 1000 meter radius:

```
!destroy all radius 1000
```