### PR TITLE
Add duration value to visual markers !smoke, !flare and !illum

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -1,13 +1,13 @@
 - [Map marker commands](#map-marker-commands)
-  * [!spawn](#spawn)
-  * [!destroy](#destroy)
-  * [!spawngroup](#spawngroup)
-  * [!smoke](#smoke)
-  * [!flare](#flare)
-  * [!illumination](#illumination)
-  * [!spawner](#spawmer)
+  - [spawn](#spawn)
+  - [destroy](#destroy)
+  - [spawngroup](#spawngroup)
+  - [smoke](#smoke)
+  - [flare](#flare)
+  - [illumination](#illumination)
+  - [spawner](#spawner)
 - [Chat commands](#chat-commands)
-  * [!defgroup](#defgroup)
+  - [defgroup](#defgroup)
 
 
 ## Map marker commands
@@ -158,7 +158,8 @@ Spawn a previous named `tanks` group in a 1000 meter radius
 
 ### smoke
 
-Create a smoke marker with the specified color on the map marker. The marker will last 5 minutes.
+Create a smoke marker with the specified color on the map marker. The marker will last for at 5 minutes. 
+The command takes a duration value in minutes. Due to DCS limitations one smoke grenade will last 5 minutes. Setting a duration of 7 minutes will result in 10 minutes smoke.
 If no color is given, a green smoke marker will be created.
 
 - `color` fuzzy match string for a color name, can be a partial color name
@@ -166,7 +167,7 @@ If no color is given, a green smoke marker will be created.
 **syntax**
 
 ```
-!smoke <color:optional>
+!smoke <color:optional> <duration:optional>
 ```
 
 available colors:
@@ -178,6 +179,8 @@ orange
 white
 blue
 ```
+
+Duration is set in minutes.
 
 **examples**
 
@@ -193,17 +196,24 @@ Create white smoke with partial color name:
 !smoke wh
 ```
 
+Create green smoke marker that lasts 30 minutes:
+
+```
+!smoke green 30
+```
+
 ### flare
 
 Fire a flare with the specified color on the map marker. One flare will be fired into the air.
 If no color is given, a green flare will be fired.
+If a duration is specified, one flare will be fired each 10 seconds for the set duration in minutes.
 
 - `color` fuzzy match string for a color name, can be a partial color name
 
 **syntax**
 
 ```
-!flare <color:optional>
+!flare <color:optional> <duration:optional>
 ```
 
 available colors:
@@ -214,6 +224,7 @@ red
 white
 yellow
 ```
+Duration is set in minutes.
 
 **examples**
 
@@ -229,20 +240,21 @@ Fire white flare with partial color name:
 !flare wh
 ```
 
+Create red flare marker that lasts 5 minutes:
+
+```
+!flare green 10
+```
+
 ### illumination
 
 Drops an illumination bomb from 500 meters AGL on the map marker. Illumination bombs drift with wind in the mission.
+One illumination bomb lasts 3 minutes. If a duration is specified, one bomb every 3 minutes is dropped for the set duration in minutes.
 
 **syntax**
 
 ```
-!illumination
-```
-
-a short version of the command is also available:
-
-```
-!illum
+!illum <duration:optional>
 ```
 
 **examples**
@@ -250,7 +262,13 @@ a short version of the command is also available:
 drop illumination bomb on map marker:
 
 ```
-!illumination
+!illum
+```
+
+Illuminate for 10 minutes:
+
+```
+!illum 10
 ```
 
 ### spawner

--- a/src/commands/parser/parser.ts
+++ b/src/commands/parser/parser.ts
@@ -281,45 +281,93 @@ function processCommand(lexer: Lexer): Command {
   }
 
   if (CommandType.Smoke === type) {
-    const nextToken = lexer.nextToken()
+    let color = undefined
+    let duration = undefined
 
-    if (
-      TokenKind.Word === nextToken.kind ||
-      TokenKind.String === nextToken.kind
-    ) {
-      const color = nextToken.value
+    const parseParts = (): void => {
+      const nextToken = lexer.nextToken()
 
-      return {
-        type: CommandType.Smoke,
-        color,
+      if (TokenKind.EOF === nextToken.kind) {
+        return
       }
+
+      // assume string or word is color
+      if (
+        TokenKind.Word === nextToken.kind ||
+        TokenKind.String === nextToken.kind
+      ) {
+        color = nextToken.value
+        return parseParts()
+      }
+
+      // assume number is duration
+      if (TokenKind.Number === nextToken.kind) {
+        duration = nextToken.value
+        return parseParts()
+      }
+
+      throw new Error('unexpected token found')
     }
+
+    parseParts()
+
     return {
       type: CommandType.Smoke,
+      color,
+      duration,
     }
   }
 
   if (CommandType.Flare === type) {
-    const nextToken = lexer.nextToken()
-    if (
-      TokenKind.Word === nextToken.kind ||
-      TokenKind.String === nextToken.kind
-    ) {
-      const color = nextToken.value
+    let color = undefined
+    let duration = undefined
 
-      return {
-        type: CommandType.Flare,
-        color,
+    const parseParts = (): void => {
+      const nextToken = lexer.nextToken()
+
+      if (TokenKind.EOF === nextToken.kind) {
+        return
       }
+
+      // assume string or word is color
+      if (
+        TokenKind.Word === nextToken.kind ||
+        TokenKind.String === nextToken.kind
+      ) {
+        color = nextToken.value
+        return parseParts()
+      }
+
+      // assume number is duration
+      if (TokenKind.Number === nextToken.kind) {
+        duration = nextToken.value
+        return parseParts()
+      }
+
+      throw new Error('unexpected token found')
     }
+
+    parseParts()
+
     return {
       type: CommandType.Flare,
+      color,
+      duration,
     }
   }
 
   if (CommandType.Illumination === type) {
+    let duration = undefined
+
+    const nextToken = lexer.nextToken()
+    // assume number is duration
+    if (TokenKind.Number === nextToken.kind) {
+      duration = nextToken.value
+    }
+
     return {
       type: CommandType.Illumination,
+      duration,
     }
   }
 
@@ -396,7 +444,7 @@ function matchCommand(input: string): CommandType {
   if ('flare' === lowerInput) {
     return CommandType.Flare
   }
-  if ('illum' === lowerInput || 'illumination' === lowerInput) {
+  if (/^illum/.test(lowerInput) === true) {
     return CommandType.Illumination
   }
   if ('spawner' === lowerInput) {

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -56,16 +56,19 @@ export interface SpawnGroupCommand extends Omit<CommandShape, 'args'> {
 
 export interface SmokeCommand extends Omit<CommandShape, 'args'> {
   type: CommandType.Smoke
-  color?: string
+  color: string | undefined
+  duration: number | undefined
 }
 
 export interface FlareCommand extends Omit<CommandShape, 'args'> {
   type: CommandType.Flare
-  color?: string
+  color: string | undefined
+  duration: number | undefined
 }
 
 export interface IlluminationCommand extends Omit<CommandShape, 'args'> {
   type: CommandType.Illumination
+  duration: number | undefined
 }
 
 export interface CreateSpawner extends Omit<CommandShape, 'args'> {


### PR DESCRIPTION
Implements #26 

You can set a duration in minutes with !smoke, !flare and !illum.
Smokes last at least 5 minutes each and therefore a value of 12 minutes results in 15 minutes smoke.
Same for illum with 3 minutes interval.

It's a very basic implementation but in my opinion we don't need the ability to set different time dimensions in the command in this case. Seconds don't make sense and hours are easy maths.

Maybe we could add "inf" for infinitely long lasting markers. But then we need them in the DB and the destroy command working for them first imo.

also changed the illum command parsing to regex instead of "illum" or "illumination" to make it a bit more robust. Only needs "illum" now but doesn't care if you type it out or miss something behind. "Illum" should be unique enough for the command.

Following the edited commands.md sections:

### smoke

Create a smoke marker with the specified color on the map marker. The marker will last for at 5 minutes. 
The command takes a duration value in minutes. Due to DCS limitations one smoke grenade will last 5 minutes. Setting a duration of 7 minutes will result in 10 minutes smoke.
If no color is given, a green smoke marker will be created.

- `color` fuzzy match string for a color name, can be a partial color name

**syntax**

```
!smoke <color:optional> <duration:optional>
```

available colors:

```
green
red
orange
white
blue
```

Duration is set in minutes.

**examples**

Create red smoke:

```
!smoke red
```

Create white smoke with partial color name:

```
!smoke wh
```

Create green smoke marker that lasts 30 minutes:

```
!smoke green 30
```

### flare

Fire a flare with the specified color on the map marker. One flare will be fired into the air.
If no color is given, a green flare will be fired.
If a duration is specified, one flare will be fired each 10 seconds for the set duration in minutes.

- `color` fuzzy match string for a color name, can be a partial color name

**syntax**

```
!flare <color:optional> <duration:optional>
```

available colors:

```
green
red
white
yellow
```
Duration is set in minutes.

**examples**

Fire red flare:

```
!flare red
```

Fire white flare with partial color name:

```
!flare wh
```

Create red flare marker that lasts 5 minutes:

```
!flare green 10
```

### illumination

Drops an illumination bomb from 500 meters AGL on the map marker. Illumination bombs drift with wind in the mission.
One illumination bomb lasts 3 minutes. If a duration is specified, one bomb every 3 minutes is dropped for the set duration in minutes.

**syntax**

```
!illum <duration:optional>
```

**examples**

drop illumination bomb on map marker:

```
!illum
```

Illuminate for 10 minutes:

```
!illum 10
```